### PR TITLE
Add POST /api/channels/:channel_id method for adding channel users to…

### DIFF
--- a/controllers/channels.js
+++ b/controllers/channels.js
@@ -4,13 +4,13 @@ var channel = require("../models/channel.js");
 
 router.get("/api/channels", (req, res) => {
     console.log('retrieve all channels');
-    channel.select( (rows) => {
+    channel.select((rows) => {
         res.json(rows);
     })
 });
 
 router.get("/api/channels/:channel_id", (req, res) => {
-    console.log('retrieve channel: '+req.params.channel_id);
+    console.log('retrieve channel: ' + req.params.channel_id);
     channel.selectWhere(req.params, (rows) => {
         res.json(rows);
     })
@@ -25,7 +25,7 @@ router.post("/api/channels", (req, res) => {
 });
 
 router.delete("/api/channels/:channel_id", (req, res) => {
-    console.log('delete channel: '+req.params.channel_id);
+    console.log('delete channel: ' + req.params.channel_id);
     console.log(req.params);
 
     channel.delete(req.params.channel_id, (result) => {
@@ -34,6 +34,32 @@ router.delete("/api/channels/:channel_id", (req, res) => {
         } else {
             res.status(200).end();
         }
+    });
+});
+
+// POST route for adding channel users
+router.post('/api/channels/:channel_id', (req, res) => {
+    console.log('add channel users');
+
+    req.body.users.forEach(userId => {
+        channel.insertChannelUsers(
+            {
+                channel_id: req.params.channel_id,
+                user_id: userId
+            },
+            (err, result) => {
+                console.log(result)
+                if (err) {
+                    console.log(err);
+
+                    res.status(500).json({ 'error': 'oops we did something bad' });
+                } else {
+                    res.status(200).json({
+                        message: 'complete'
+                    });
+                }
+            }
+        );
     });
 });
 

--- a/models/channel.js
+++ b/models/channel.js
@@ -50,6 +50,13 @@ let channels = {
             cb(data);
         });
     },
+    insertChannelUsers: (channelUsers, cb) => {
+        let query = {
+            table: 'channel_user',
+            data: channelUsers
+        };
+        orm.insert(query, cb);
+    }
 
 };
 


### PR DESCRIPTION
… a channel

This PR takes an array of `user_id`s for each user being added to a channel and the `channel_id` in the request URL. The controller, currently, parses the array and returns a success message for each user added.

As a follow up, we should add a query to `INSERT` all users in one query. 

Sample request:

```
{
	"users": [ 3, 4, 5 ]
}
```

Sample response:

```
{
    "message": "complete"
}
```