### PR TITLE
Add POST /api/groups for creating direct message groups, create group…

### DIFF
--- a/config/orm.js
+++ b/config/orm.js
@@ -111,6 +111,15 @@ let orm = {
         connection.query(queryString, queryArray, function (error, result) {
             callback(error, result);
         });
+    },
+    insertNull: function (query, callback) {
+        let queryString = 'INSERT INTO ?? (??) VALUES (NULL)';
+
+        let sqlQuery = connection.query(queryString, [query.table, query.columns], function (error, result) {
+            callback(error, result);
+        });
+
+        console.log(sqlQuery)
     }
 };
 

--- a/controllers/channels.js
+++ b/controllers/channels.js
@@ -76,4 +76,25 @@ router.post('/api/channels/:channel_id', (req, res) => {
     });
 });
 
+// POST route for creating a channel
+router.post('/api/channels', (req, res) => {
+    console.log('create channel');
+
+    // @TODO check if channel exists
+    // do stuff
+    // else
+    channel.create(req.body, (err, result) => {
+        if (err) {
+            console.log(err);
+
+            res.status(500).json({ 'error': 'oops we did something bad' });
+        } else {
+            res.status(200).json({
+                channel_id: result.insertId,
+                channel_name: req.body.channel_name
+            });
+        }
+    });
+});
+
 module.exports = router;

--- a/controllers/groups.js
+++ b/controllers/groups.js
@@ -1,0 +1,25 @@
+let express = require('express');
+let group = require('../models/group.js');
+let router = express.Router();
+
+// POST route for creating a direct message group
+router.post('/api/groups', (req, res) => {
+    console.log('Create direct message group');
+
+    // @TODO check if channel exists
+    // do stuff
+    // else
+    group.create(req.body, (err, result) => {
+        if (err) {
+            console.log(err);
+
+            res.status(500).json({ 'error': 'oops we did something bad' });
+        } else {
+            res.status(200).json({
+                direct_group_id: result.insertId
+            });
+        }
+    });
+});
+
+module.exports = router;

--- a/models/group.js
+++ b/models/group.js
@@ -1,0 +1,14 @@
+let orm = require('../config/orm.js');
+
+let group = {
+    create: (groupObj, cb) => {
+        let query = {
+            table: 'direct_groups',
+            columns: 'direct_group_id',
+            data: groupObj
+        };
+        orm.insertNull(query, cb);
+    }
+};
+
+module.exports = group;

--- a/server.js
+++ b/server.js
@@ -23,9 +23,11 @@ app.use(express.json());
 var userRoute = require("./controllers/users.js");
 var channelRoute = require("./controllers/channels.js");
 var messageRoute = require("./controllers/messages.js");
+var groupRoute = require("./controllers/groups.js");
 app.use(userRoute);
 app.use(channelRoute);
 app.use(messageRoute);
+app.use(groupRoute);
 
 const server = app.listen(PORT, function () {
     console.log("Server listening on: http://localhost:" + PORT);


### PR DESCRIPTION
…s controller and model, add INSERT null value query

The `/groups` endpoint manages DM's. It currently allows you to create new DM groups by submitting an empty body request, and returns the `direct_group_id`.

*POST /api/groups

Response:

```
{
    "direct_group_id": 3
}
```